### PR TITLE
Added Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:20.04
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libgsl-dev \
+    python3 \
+    python3-pip \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+RUN pip3 install numpy scipy
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files to the container
+COPY . /app
+
+# Build the project
+RUN make build
+
+# Set default command
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -18,24 +18,11 @@ Lightning Network.
 
 ## Install requirements
 
-Install the requirements: 
-
-```sh
-sudo apt-get install gcc
-sudo apt-get install libgsl-dev
-sudo apt-get install python
-sudo apt-get install python-pip
-pip install numpy
-pip install scipy
-```
-
-## Build
-
-Build CLoTH:
-
-```sh
-make build
-```
+1. Have Docker Desktop for Mac/Windows
+2. cd to this project folder
+3. Build the image: run ```docker build -t cloth_simulation .```
+4. Run the container: ```docker run -it --rm cloth_simulation```
+5. the rest is the same as the original
 
 ## Run
 
@@ -44,6 +31,10 @@ Run CLoTH:
 ```sh
 ./run-simulation.sh <seed> <output-directory>
 ```
+additional notes:
+<seed>: any random number
+<output-directory>: the output folder
+example: ./run-simulation.sh 42 ./output
 
 where `seed` is the seed used for random variables of the simulator and
 `output-directory` is the path of the directory where to store the output files


### PR DESCRIPTION
This PR introduces Docker support to simplify environment setup and execution of the simulation. Changes include:

Added Dockerfile to define the containerized environment with necessary dependencies (gcc, libgsl-dev, numpy, scipy).

Included instructions for building and running the simulation via Docker on Readme.md:
docker build -t cloth-simulator .
docker ./run-simulation.sh <seed> output
Enables reproducible and portable simulations without system-specific dependencies.